### PR TITLE
more flexible ObjectSerializer

### DIFF
--- a/base/src/main/java/eu/okaeri/configs/serdes/ObjectSerializer.java
+++ b/base/src/main/java/eu/okaeri/configs/serdes/ObjectSerializer.java
@@ -4,7 +4,7 @@ import eu.okaeri.configs.schema.GenericsDeclaration;
 
 public interface ObjectSerializer<T> {
 
-    Class<? super T> getType();
+    boolean supports(Class<? super T> type);
 
     void serialize(T object, SerializationData data);
 

--- a/base/src/main/java/eu/okaeri/configs/serdes/TransformerRegistry.java
+++ b/base/src/main/java/eu/okaeri/configs/serdes/TransformerRegistry.java
@@ -5,12 +5,13 @@ import eu.okaeri.configs.schema.GenericsPair;
 import eu.okaeri.configs.serdes.impl.ObjectToStringTransformer;
 
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class TransformerRegistry {
 
     private final Map<GenericsPair, ObjectTransformer> transformerMap = new ConcurrentHashMap<>();
-    private final Map<Class<?>, ObjectSerializer> serializerMap = new ConcurrentHashMap<>();
+    private final Set<ObjectSerializer> serializerSet = ConcurrentHashMap.newKeySet();
 
     public void register(ObjectTransformer transformer) {
         this.transformerMap.put(transformer.getPair(), transformer);
@@ -52,7 +53,7 @@ public class TransformerRegistry {
     }
 
     public void register(ObjectSerializer serializer) {
-        this.serializerMap.put(serializer.getType(), serializer);
+        this.serializerSet.add(serializer);
     }
 
     public ObjectTransformer getTransformer(GenericsDeclaration from, GenericsDeclaration to) {
@@ -65,6 +66,9 @@ public class TransformerRegistry {
     }
 
     public ObjectSerializer getSerializer(Class<?> clazz) {
-        return this.serializerMap.get(clazz);
+        return this.serializerSet.stream()
+                .filter(serializer -> serializer.supports(clazz))
+                .findFirst()
+                .orElse(null);
     }
 }

--- a/bukkit-serdes/src/main/java/eu/okaeri/configs/bukkit/serdes/impl/ItemMetaSerializer.java
+++ b/bukkit-serdes/src/main/java/eu/okaeri/configs/bukkit/serdes/impl/ItemMetaSerializer.java
@@ -22,8 +22,8 @@ public class ItemMetaSerializer implements ObjectSerializer<ItemMeta> {
     private static final char ALT_COLOR_CHAR = '&';
 
     @Override
-    public Class<? super ItemMeta> getType() {
-        return ItemMeta.class;
+    public boolean supports(Class<? super ItemMeta> type) {
+        return type.isAssignableFrom(ItemMeta.class);
     }
 
     @Override

--- a/bukkit-serdes/src/main/java/eu/okaeri/configs/bukkit/serdes/impl/ItemStackSerializer.java
+++ b/bukkit-serdes/src/main/java/eu/okaeri/configs/bukkit/serdes/impl/ItemStackSerializer.java
@@ -11,8 +11,8 @@ import org.bukkit.inventory.meta.ItemMeta;
 public class ItemStackSerializer implements ObjectSerializer<ItemStack> {
 
     @Override
-    public Class<? super ItemStack> getType() {
-        return ItemStack.class;
+    public boolean supports(Class<? super ItemStack> type) {
+        return type.isAssignableFrom(ItemStack.class);
     }
 
     @Override

--- a/bukkit-serdes/src/main/java/eu/okaeri/configs/bukkit/serdes/impl/LocationSerializer.java
+++ b/bukkit-serdes/src/main/java/eu/okaeri/configs/bukkit/serdes/impl/LocationSerializer.java
@@ -10,8 +10,8 @@ import org.bukkit.World;
 public class LocationSerializer implements ObjectSerializer<Location> {
 
     @Override
-    public Class<? super Location> getType() {
-        return Location.class;
+    public boolean supports(Class<? super Location> type) {
+        return type.isAssignableFrom(Location.class);
     }
 
     @Override

--- a/bukkit-serdes/src/main/java/eu/okaeri/configs/bukkit/serdes/impl/PotionEffectSerializer.java
+++ b/bukkit-serdes/src/main/java/eu/okaeri/configs/bukkit/serdes/impl/PotionEffectSerializer.java
@@ -10,8 +10,8 @@ import org.bukkit.potion.PotionEffectType;
 public class PotionEffectSerializer implements ObjectSerializer<PotionEffect> {
 
     @Override
-    public Class<? super PotionEffect> getType() {
-        return PotionEffect.class;
+    public boolean supports(Class<? super PotionEffect> type) {
+        return type.isAssignableFrom(PotionEffect.class);
     }
 
     @Override

--- a/bukkit/src/test/java/test/LocationSerializer.java
+++ b/bukkit/src/test/java/test/LocationSerializer.java
@@ -10,8 +10,8 @@ import org.bukkit.World;
 public class LocationSerializer implements ObjectSerializer<Location> {
 
     @Override
-    public Class<? super Location> getType() {
-        return Location.class;
+    public boolean supports(Class<? super Location> type) {
+        return type.isAssignableFrom(Location.class);
     }
 
     @Override


### PR DESCRIPTION
Currently, ObjectSerializer is quite inflexible. In my scenario, I want to create a reflection-based implementation that works only for `data class` from Kotlin. With the current implementation, I'm not able to do that.