### PR TITLE
fix: ignore static fields

### DIFF
--- a/core/src/main/java/eu/okaeri/configs/schema/FieldDeclaration.java
+++ b/core/src/main/java/eu/okaeri/configs/schema/FieldDeclaration.java
@@ -59,6 +59,10 @@ public class FieldDeclaration {
                 return null;
             }
 
+            if (Modifier.isStatic(field.getModifiers())) {
+                return null;
+            }
+
             if ("serialVersionUID".equals(field.getName())) {
                 return null;
             }


### PR DESCRIPTION
Ignores static fields for OkaeriConfig objects. Mainly for Kotlin compatability since we can't access `companion object` fields.

As far as I'm aware, Okaeri doesn't support static fields for configs *anyways* so this shouldn't have any real affect