### PR TITLE
Add separate internalState migrator

### DIFF
--- a/core-test-commons/src/main/java/eu/okaeri/configs/test/GoldenFileAssertion.java
+++ b/core-test-commons/src/main/java/eu/okaeri/configs/test/GoldenFileAssertion.java
@@ -136,8 +136,8 @@ public class GoldenFileAssertion {
         String goldenContent = Files.readString(goldenPath);
 
         // Apply normalizers to both contents
-        String normalizedGolden = this.applyNormalizers(goldenContent);
-        String normalizedCurrent = this.applyNormalizers(this.currentContent);
+        String normalizedGolden = this.applyNormalizers(goldenContent).replace("\r\n", "\n");
+        String normalizedCurrent = this.applyNormalizers(this.currentContent).replace("\r\n", "\n");
 
         if (!normalizedCurrent.equals(normalizedGolden)) {
             if (this.verbose) {

--- a/core/src/main/java/eu/okaeri/configs/OkaeriConfig.java
+++ b/core/src/main/java/eu/okaeri/configs/OkaeriConfig.java
@@ -7,6 +7,8 @@ import eu.okaeri.configs.exception.OkaeriConfigException;
 import eu.okaeri.configs.exception.OkaeriException;
 import eu.okaeri.configs.migrate.ConfigMigration;
 import eu.okaeri.configs.migrate.builtin.NamedMigration;
+import eu.okaeri.configs.migrate.view.ConfigView;
+import eu.okaeri.configs.migrate.view.InternalStateView;
 import eu.okaeri.configs.migrate.view.RawConfigView;
 import eu.okaeri.configs.schema.ConfigDeclaration;
 import eu.okaeri.configs.schema.FieldDeclaration;
@@ -835,6 +837,35 @@ public abstract class OkaeriConfig {
     }
 
     /**
+     * This will run TRUE raw migrations (ZERO (de)serialization) on values.
+     * This allows for migrations to complete with values that don't satisfy a
+     * serializer's requirements (yet).
+     * <p>
+     * By the end of ALL given migrations, serializer requirements should
+     * be satisfied (unless the user just has an invalid structure).
+     * For the regular {@code migrate} methods, serializer requirements must
+     * be satisfied after EACH migration, which is more restrictive but allows
+     * for interacting with (de)serialized values.
+     * <p>
+     * Internal state migrations should be called BEFORE {@code migrate}
+     * (if {@code migrate} is called at all). If it's called after, serializers
+     * may not have their requirements met and thus fail when loading the config.
+     */
+    public OkaeriConfig migrateInternalState(@NonNull ConfigMigration... migrations) throws OkaeriException {
+        return this.migrateInternalState(
+            (performed) -> {
+                try {
+                    this.update();
+                } catch (OkaeriException exception) {
+                    throw new OkaeriException("failed #migrateInternalState due to update error after migrations (not saving)", exception);
+                }
+                this.save();
+            },
+            migrations
+        );
+    }
+
+    /**
      * Performs migrations on the current in-memory config state and invokes callback
      * with the count of performed migrations.
      * <p>
@@ -852,7 +883,29 @@ public abstract class OkaeriConfig {
      * @see #migrate(ConfigMigration...) for typical usage with automatic save
      */
     public OkaeriConfig migrate(@NonNull Consumer<Long> callback, @NonNull ConfigMigration... migrations) throws OkaeriException {
-        RawConfigView view = new RawConfigView(this);
+        return this.migrate(new RawConfigView(this), callback, migrations);
+    }
+
+    /**
+     * This will run TRUE raw migrations (ZERO (de)serialization) on values.
+     * This allows for migrations to complete with values that don't satisfy a
+     * serializer's requirements (yet).
+     * <p>
+     * By the end of ALL given migrations, serializer requirements should
+     * be satisfied (unless the user just has an invalid structure).
+     * For the regular {@code migrate} methods, serializer requirements must
+     * be satisfied after EACH migration, which is more restrictive but allows
+     * for interacting with (de)serialized values.
+     * <p>
+     * Internal state migrations should be called BEFORE {@code migrate}
+     * (if {@code migrate} is called at all). If it's called after, serializers
+     * may not have their requirements met and thus fail when loading the config.
+     */
+    public OkaeriConfig migrateInternalState(@NonNull Consumer<Long> callback, @NonNull ConfigMigration... migrations) throws OkaeriException {
+        return this.migrate(new InternalStateView(this), callback, migrations);
+    }
+
+    private OkaeriConfig migrate(@NonNull ConfigView view, @NonNull Consumer<Long> callback, @NonNull ConfigMigration... migrations) throws OkaeriException {
         long performed = Arrays.stream(migrations)
             .filter(migration -> {
                 try {

--- a/core/src/main/java/eu/okaeri/configs/OkaeriConfig.java
+++ b/core/src/main/java/eu/okaeri/configs/OkaeriConfig.java
@@ -842,7 +842,7 @@ public abstract class OkaeriConfig {
      * <p>
      * <b>IMPORTANT: Call order matters!</b> This method is <b>imperative</b> and runs
      * immediately on the current state. You MUST call {@link #load()} BEFORE migrate(),
-     * otherwise migrations will run on default field values instead of your saved data.
+     * otherwise migrations will run on nothing (internal state will be empty).
      * <p>
      * This will run TRUE raw migrations (ZERO (de)serialization) on values.
      * This allows for migrations to complete with values that don't satisfy a
@@ -867,7 +867,7 @@ public abstract class OkaeriConfig {
      * <p>
      * Incorrect usage (common mistake):
      * <pre>{@code
-     * config.migrateInternalState(migration);  // WRONG: Runs on defaults, not saved data!
+     * config.migrateInternalState(migration);  // WRONG: Runs on nothing, not saved data!
      * config.load();                           // Data loaded but migration already ran
      * }</pre>
      *
@@ -917,7 +917,7 @@ public abstract class OkaeriConfig {
      * <p>
      * <b>IMPORTANT: Call order matters!</b> This method is <b>imperative</b> and runs
      * immediately on the current state. You MUST call {@link #load()} BEFORE migrate(),
-     * otherwise migrations will run on default field values instead of your saved data.
+     * otherwise migrations will run on nothing (internal state will be empty).
      * <p>
      * This will run TRUE raw migrations (ZERO (de)serialization) on values.
      * This allows for migrations to complete with values that don't satisfy a

--- a/core/src/main/java/eu/okaeri/configs/OkaeriConfig.java
+++ b/core/src/main/java/eu/okaeri/configs/OkaeriConfig.java
@@ -799,7 +799,7 @@ public abstract class OkaeriConfig {
 
     /**
      * Performs migrations on the current in-memory config state, validates the result,
-     * and saves to file.
+     * and {@link #save() saves to file}.
      * <p>
      * <b>IMPORTANT: Call order matters!</b> This method is <b>imperative</b> and runs
      * immediately on the current state. You MUST call {@link #load()} BEFORE migrate(),
@@ -837,6 +837,13 @@ public abstract class OkaeriConfig {
     }
 
     /**
+     * Performs migrations on the current internal state config state, validates the result,
+     * {@link #update() updates the config object's fields}, and {@link #save() saves to file}.
+     * <p>
+     * <b>IMPORTANT: Call order matters!</b> This method is <b>imperative</b> and runs
+     * immediately on the current state. You MUST call {@link #load()} BEFORE migrate(),
+     * otherwise migrations will run on default field values instead of your saved data.
+     * <p>
      * This will run TRUE raw migrations (ZERO (de)serialization) on values.
      * This allows for migrations to complete with values that don't satisfy a
      * serializer's requirements (yet).
@@ -850,6 +857,24 @@ public abstract class OkaeriConfig {
      * Internal state migrations should be called BEFORE {@code migrate}
      * (if {@code migrate} is called at all). If it's called after, serializers
      * may not have their requirements met and thus fail when loading the config.
+     * <p>
+     * Correct usage:
+     * <pre>{@code
+     * config.load();                           // 1. Load existing data first
+     * config.migrateInternalState(migration);  // 2. Migrate loaded data
+     * // update() is called automatically by migrateInternalState()
+     * }</pre>
+     * <p>
+     * Incorrect usage (common mistake):
+     * <pre>{@code
+     * config.migrateInternalState(migration);  // WRONG: Runs on defaults, not saved data!
+     * config.load();                           // Data loaded but migration already ran
+     * }</pre>
+     *
+     * @param migrations migrations to be performed
+     * @return this instance
+     * @throws OkaeriException if {@link #configurer} is null or migration fails
+     * @see #migrate(ConfigMigration...) for migrations with (de)serialized values
      */
     public OkaeriConfig migrateInternalState(@NonNull ConfigMigration... migrations) throws OkaeriException {
         return this.migrateInternalState(
@@ -887,6 +912,13 @@ public abstract class OkaeriConfig {
     }
 
     /**
+     * Performs migrations on the current internal state config state and invokes callback
+     * with the count of performed migrations.
+     * <p>
+     * <b>IMPORTANT: Call order matters!</b> This method is <b>imperative</b> and runs
+     * immediately on the current state. You MUST call {@link #load()} BEFORE migrate(),
+     * otherwise migrations will run on default field values instead of your saved data.
+     * <p>
      * This will run TRUE raw migrations (ZERO (de)serialization) on values.
      * This allows for migrations to complete with values that don't satisfy a
      * serializer's requirements (yet).
@@ -900,6 +932,13 @@ public abstract class OkaeriConfig {
      * Internal state migrations should be called BEFORE {@code migrate}
      * (if {@code migrate} is called at all). If it's called after, serializers
      * may not have their requirements met and thus fail when loading the config.
+     *
+     * @param callback   consumer invoked with performed migrations count (if > 0)
+     * @param migrations migrations to be performed
+     * @return this instance
+     * @throws OkaeriException if {@link #configurer} is null or migration fails
+     * @see #migrateInternalState(ConfigMigration...) for typical usage with automatic save
+     * @see #migrate(Consumer, ConfigMigration...) for migrations with (de)serialized values
      */
     public OkaeriConfig migrateInternalState(@NonNull Consumer<Long> callback, @NonNull ConfigMigration... migrations) throws OkaeriException {
         return this.migrate(new InternalStateView(this), callback, migrations);

--- a/core/src/main/java/eu/okaeri/configs/OkaeriConfig.java
+++ b/core/src/main/java/eu/okaeri/configs/OkaeriConfig.java
@@ -720,9 +720,9 @@ public abstract class OkaeriConfig {
      * @throws OkaeriException if {@link #configurer} or {@link #bindFile} is null or loading fails
      */
     public OkaeriConfig load(@NonNull File file) throws OkaeriException {
-        try {
-            return this.load(new FileInputStream(file));
-        } catch (FileNotFoundException exception) {
+        try (FileInputStream inputStream = new FileInputStream(file)) {
+            return this.load(inputStream);
+        } catch (IOException exception) {
             throw new OkaeriException("failed #load using file " + file, exception);
         }
     }

--- a/core/src/main/java/eu/okaeri/configs/migrate/ConfigMigration.java
+++ b/core/src/main/java/eu/okaeri/configs/migrate/ConfigMigration.java
@@ -1,11 +1,11 @@
 package eu.okaeri.configs.migrate;
 
 import eu.okaeri.configs.OkaeriConfig;
-import eu.okaeri.configs.migrate.view.RawConfigView;
+import eu.okaeri.configs.migrate.view.ConfigView;
 import lombok.NonNull;
 
 @FunctionalInterface
 public interface ConfigMigration {
 
-    boolean migrate(@NonNull OkaeriConfig config, @NonNull RawConfigView view);
+    boolean migrate(@NonNull OkaeriConfig config, @NonNull ConfigView view);
 }

--- a/core/src/main/java/eu/okaeri/configs/migrate/builtin/action/SimpleCopyMigration.java
+++ b/core/src/main/java/eu/okaeri/configs/migrate/builtin/action/SimpleCopyMigration.java
@@ -2,7 +2,7 @@ package eu.okaeri.configs.migrate.builtin.action;
 
 import eu.okaeri.configs.OkaeriConfig;
 import eu.okaeri.configs.migrate.ConfigMigration;
-import eu.okaeri.configs.migrate.view.RawConfigView;
+import eu.okaeri.configs.migrate.view.ConfigView;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
@@ -17,7 +17,7 @@ public class SimpleCopyMigration implements ConfigMigration {
     private final String toKey;
 
     @Override
-    public boolean migrate(@NonNull OkaeriConfig config, @NonNull RawConfigView view) {
+    public boolean migrate(@NonNull OkaeriConfig config, @NonNull ConfigView view) {
 
         if (!view.exists(this.fromKey)) {
             return false;

--- a/core/src/main/java/eu/okaeri/configs/migrate/builtin/action/SimpleDeleteMigration.java
+++ b/core/src/main/java/eu/okaeri/configs/migrate/builtin/action/SimpleDeleteMigration.java
@@ -2,7 +2,7 @@ package eu.okaeri.configs.migrate.builtin.action;
 
 import eu.okaeri.configs.OkaeriConfig;
 import eu.okaeri.configs.migrate.ConfigMigration;
-import eu.okaeri.configs.migrate.view.RawConfigView;
+import eu.okaeri.configs.migrate.view.ConfigView;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
@@ -14,7 +14,7 @@ public class SimpleDeleteMigration implements ConfigMigration {
     private final String key;
 
     @Override
-    public boolean migrate(@NonNull OkaeriConfig config, @NonNull RawConfigView view) {
+    public boolean migrate(@NonNull OkaeriConfig config, @NonNull ConfigView view) {
 
         if (!view.exists(this.key)) {
             return false;

--- a/core/src/main/java/eu/okaeri/configs/migrate/builtin/action/SimpleMoveMigration.java
+++ b/core/src/main/java/eu/okaeri/configs/migrate/builtin/action/SimpleMoveMigration.java
@@ -2,7 +2,7 @@ package eu.okaeri.configs.migrate.builtin.action;
 
 import eu.okaeri.configs.OkaeriConfig;
 import eu.okaeri.configs.migrate.ConfigMigration;
-import eu.okaeri.configs.migrate.view.RawConfigView;
+import eu.okaeri.configs.migrate.view.ConfigView;
 import lombok.AllArgsConstructor;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -20,7 +20,7 @@ public class SimpleMoveMigration implements ConfigMigration {
     private Function<Object, Object> updateFunction;
 
     @Override
-    public boolean migrate(@NonNull OkaeriConfig config, @NonNull RawConfigView view) {
+    public boolean migrate(@NonNull OkaeriConfig config, @NonNull ConfigView view) {
 
         if (!view.exists(this.fromKey)) {
             return false;

--- a/core/src/main/java/eu/okaeri/configs/migrate/builtin/action/SimpleSupplyMigration.java
+++ b/core/src/main/java/eu/okaeri/configs/migrate/builtin/action/SimpleSupplyMigration.java
@@ -2,7 +2,7 @@ package eu.okaeri.configs.migrate.builtin.action;
 
 import eu.okaeri.configs.OkaeriConfig;
 import eu.okaeri.configs.migrate.ConfigMigration;
-import eu.okaeri.configs.migrate.view.RawConfigView;
+import eu.okaeri.configs.migrate.view.ConfigView;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
@@ -17,7 +17,7 @@ public class SimpleSupplyMigration implements ConfigMigration {
     private final Supplier supplier;
 
     @Override
-    public boolean migrate(@NonNull OkaeriConfig config, @NonNull RawConfigView view) {
+    public boolean migrate(@NonNull OkaeriConfig config, @NonNull ConfigView view) {
 
         if (view.exists(this.key)) {
             return false;

--- a/core/src/main/java/eu/okaeri/configs/migrate/builtin/action/SimpleUpdateMigration.java
+++ b/core/src/main/java/eu/okaeri/configs/migrate/builtin/action/SimpleUpdateMigration.java
@@ -2,7 +2,7 @@ package eu.okaeri.configs.migrate.builtin.action;
 
 import eu.okaeri.configs.OkaeriConfig;
 import eu.okaeri.configs.migrate.ConfigMigration;
-import eu.okaeri.configs.migrate.view.RawConfigView;
+import eu.okaeri.configs.migrate.view.ConfigView;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
@@ -18,7 +18,7 @@ public class SimpleUpdateMigration implements ConfigMigration {
     private final Function<Object, Object> function;
 
     @Override
-    public boolean migrate(@NonNull OkaeriConfig config, @NonNull RawConfigView view) {
+    public boolean migrate(@NonNull OkaeriConfig config, @NonNull ConfigView view) {
         Object oldValue = view.get(this.key);
         Object newValue = this.function.apply(oldValue);
         view.set(this.key, newValue);

--- a/core/src/main/java/eu/okaeri/configs/migrate/builtin/special/SimpleConditionalMigration.java
+++ b/core/src/main/java/eu/okaeri/configs/migrate/builtin/special/SimpleConditionalMigration.java
@@ -2,7 +2,7 @@ package eu.okaeri.configs.migrate.builtin.special;
 
 import eu.okaeri.configs.OkaeriConfig;
 import eu.okaeri.configs.migrate.ConfigMigration;
-import eu.okaeri.configs.migrate.view.RawConfigView;
+import eu.okaeri.configs.migrate.view.ConfigView;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
@@ -16,7 +16,7 @@ public class SimpleConditionalMigration implements ConfigMigration {
     private final ConfigMigration migrationFalse;
 
     @Override
-    public boolean migrate(@NonNull OkaeriConfig config, @NonNull RawConfigView view) {
+    public boolean migrate(@NonNull OkaeriConfig config, @NonNull ConfigView view) {
 
         if (this.when.migrate(config, view)) {
             return this.migrationTrue.migrate(config, view);

--- a/core/src/main/java/eu/okaeri/configs/migrate/builtin/special/SimpleExistsMigration.java
+++ b/core/src/main/java/eu/okaeri/configs/migrate/builtin/special/SimpleExistsMigration.java
@@ -2,7 +2,7 @@ package eu.okaeri.configs.migrate.builtin.special;
 
 import eu.okaeri.configs.OkaeriConfig;
 import eu.okaeri.configs.migrate.ConfigMigration;
-import eu.okaeri.configs.migrate.view.RawConfigView;
+import eu.okaeri.configs.migrate.view.ConfigView;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
@@ -14,7 +14,7 @@ public class SimpleExistsMigration implements ConfigMigration {
     private final String key;
 
     @Override
-    public boolean migrate(@NonNull OkaeriConfig config, @NonNull RawConfigView view) {
+    public boolean migrate(@NonNull OkaeriConfig config, @NonNull ConfigView view) {
         return view.exists(this.key);
     }
 }

--- a/core/src/main/java/eu/okaeri/configs/migrate/builtin/special/SimpleMultiMigration.java
+++ b/core/src/main/java/eu/okaeri/configs/migrate/builtin/special/SimpleMultiMigration.java
@@ -2,7 +2,7 @@ package eu.okaeri.configs.migrate.builtin.special;
 
 import eu.okaeri.configs.OkaeriConfig;
 import eu.okaeri.configs.migrate.ConfigMigration;
-import eu.okaeri.configs.migrate.view.RawConfigView;
+import eu.okaeri.configs.migrate.view.ConfigView;
 import lombok.AllArgsConstructor;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -19,7 +19,7 @@ public class SimpleMultiMigration implements ConfigMigration {
     private boolean requireAll = false;
 
     @Override
-    public boolean migrate(@NonNull OkaeriConfig config, @NonNull RawConfigView view) {
+    public boolean migrate(@NonNull OkaeriConfig config, @NonNull ConfigView view) {
 
         long performed = Arrays.stream(this.migrations)
             .filter(migration -> migration.migrate(config, view))

--- a/core/src/main/java/eu/okaeri/configs/migrate/builtin/special/SimpleNoopMigration.java
+++ b/core/src/main/java/eu/okaeri/configs/migrate/builtin/special/SimpleNoopMigration.java
@@ -2,7 +2,7 @@ package eu.okaeri.configs.migrate.builtin.special;
 
 import eu.okaeri.configs.OkaeriConfig;
 import eu.okaeri.configs.migrate.ConfigMigration;
-import eu.okaeri.configs.migrate.view.RawConfigView;
+import eu.okaeri.configs.migrate.view.ConfigView;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 
@@ -12,7 +12,7 @@ public class SimpleNoopMigration implements ConfigMigration {
     private final boolean result;
 
     @Override
-    public boolean migrate(@NonNull OkaeriConfig config, @NonNull RawConfigView view) {
+    public boolean migrate(@NonNull OkaeriConfig config, @NonNull ConfigView view) {
         return this.result;
     }
 }

--- a/core/src/main/java/eu/okaeri/configs/migrate/builtin/special/SimpleNotMigration.java
+++ b/core/src/main/java/eu/okaeri/configs/migrate/builtin/special/SimpleNotMigration.java
@@ -2,7 +2,7 @@ package eu.okaeri.configs.migrate.builtin.special;
 
 import eu.okaeri.configs.OkaeriConfig;
 import eu.okaeri.configs.migrate.ConfigMigration;
-import eu.okaeri.configs.migrate.view.RawConfigView;
+import eu.okaeri.configs.migrate.view.ConfigView;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
@@ -14,7 +14,7 @@ public class SimpleNotMigration implements ConfigMigration {
     private final ConfigMigration migration;
 
     @Override
-    public boolean migrate(@NonNull OkaeriConfig config, @NonNull RawConfigView view) {
+    public boolean migrate(@NonNull OkaeriConfig config, @NonNull ConfigView view) {
         return !this.migration.migrate(config, view);
     }
 }

--- a/core/src/main/java/eu/okaeri/configs/migrate/builtin/special/SimplePredicateMigration.java
+++ b/core/src/main/java/eu/okaeri/configs/migrate/builtin/special/SimplePredicateMigration.java
@@ -2,7 +2,7 @@ package eu.okaeri.configs.migrate.builtin.special;
 
 import eu.okaeri.configs.OkaeriConfig;
 import eu.okaeri.configs.migrate.ConfigMigration;
-import eu.okaeri.configs.migrate.view.RawConfigView;
+import eu.okaeri.configs.migrate.view.ConfigView;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
@@ -18,7 +18,7 @@ public class SimplePredicateMigration<T> implements ConfigMigration {
 
     @Override
     @SuppressWarnings("unchecked")
-    public boolean migrate(@NonNull OkaeriConfig config, @NonNull RawConfigView view) {
+    public boolean migrate(@NonNull OkaeriConfig config, @NonNull ConfigView view) {
 
         if (!view.exists(this.key)) {
             return false;

--- a/core/src/main/java/eu/okaeri/configs/migrate/view/ConfigView.java
+++ b/core/src/main/java/eu/okaeri/configs/migrate/view/ConfigView.java
@@ -1,0 +1,157 @@
+package eu.okaeri.configs.migrate.view;
+
+import eu.okaeri.configs.OkaeriConfig;
+import eu.okaeri.configs.configurer.Configurer;
+import eu.okaeri.configs.serdes.SerdesContext;
+import eu.okaeri.configs.serdes.TypedKeyReader;
+import eu.okaeri.configs.serdes.TypedKeyWriter;
+import lombok.AllArgsConstructor;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * @see RawConfigView
+ * @see InternalStateView
+ */
+@AllArgsConstructor
+@RequiredArgsConstructor
+public abstract class ConfigView implements TypedKeyReader, TypedKeyWriter {
+
+    protected final OkaeriConfig config;
+    protected String nestedSeparator = "\\.";
+
+    /**
+     * Checks if a key exists at the specified path.
+     *
+     * @param key the dot-separated key path
+     * @return true if the key exists
+     */
+    public abstract boolean exists(@NonNull String key);
+
+    /**
+     * Removes the value at the specified key path.
+     *
+     * @param key the dot-separated key path
+     * @return the previous value, or null
+     */
+    public abstract Object remove(@NonNull String key);
+
+    // ==================== INTERFACE REQUIREMENTS ====================
+
+    @Override
+    public Configurer getConfigurer() {
+        return this.config.getConfigurer();
+    }
+
+    @Override
+    public SerdesContext getReaderContext(@NonNull String key) {
+        return SerdesContext.of(this.getConfigurer(), this.config.getContext(), null);
+    }
+
+    @Override
+    public SerdesContext getWriterContext(@NonNull String key) {
+        return SerdesContext.of(this.getConfigurer(), this.config.getContext(), null);
+    }
+
+    // ==================== MIGRATION CONVENIENCE METHODS ====================
+
+    /**
+     * Gets the raw value at the specified key path (alias for {@link #getRaw}).
+     *
+     * @param key the dot-separated key path
+     * @return the raw value, or null if not found
+     */
+    public Object get(@NonNull String key) {
+        return this.getRaw(key);
+    }
+
+    @Override
+    public Object getRawOrNull(@NonNull String key) {
+        return this.getRaw(key);
+    }
+
+    // ==================== NESTED PATH HELPERS ====================
+
+    protected boolean valueExists(Map<?, ?> document, String path) {
+        String[] split = path.split(this.nestedSeparator);
+        for (int i = 0; i < split.length; i++) {
+            String part = split[i];
+            if (i == (split.length - 1)) {
+                return document.containsKey(part);
+            }
+            Object element = document.get(part);
+            if (element instanceof Map) {
+                document = (Map<?, ?>) element;
+                continue;
+            }
+            return false;
+        }
+        return false;
+    }
+
+    protected Object valueExtract(Map<?, ?> document, String path) {
+        String[] split = path.split(this.nestedSeparator);
+        for (int i = 0; i < split.length; i++) {
+            String part = split[i];
+            Object element = document.get(part);
+            if (i == (split.length - 1)) {
+                return element;
+            }
+            if (element instanceof Map) {
+                document = (Map<?, ?>) element;
+                continue;
+            }
+            // can't traverse deeper - return null
+            return null;
+        }
+        return null;
+    }
+
+    @SuppressWarnings("unchecked")
+    protected Object valuePut(Map<?, ?> document, String path, Object value) {
+        String[] split = path.split(this.nestedSeparator);
+        Map<Object, Object> current = (Map<Object, Object>) document;
+        for (int i = 0; i < split.length; i++) {
+            String part = split[i];
+            if (i == (split.length - 1)) {
+                return current.put(part, value);
+            }
+            Object element = current.get(part);
+            if (element instanceof Map) {
+                current = (Map<Object, Object>) element;
+                continue;
+            }
+            if (element != null) {
+                String elementStr = element.getClass().getSimpleName();
+                throw new IllegalArgumentException("Cannot insert '" + path + "': " +
+                    "type conflict (ended at index " + i + " [" + part + ":" + elementStr + "])");
+            }
+            Map<Object, Object> map = new LinkedHashMap<>();
+            current.put(part, map);
+            current = map;
+        }
+        throw new IllegalArgumentException("Cannot put '" + path + "'");
+    }
+
+    @SuppressWarnings("unchecked")
+    protected Object valueRemove(Map<?, ?> document, String path) {
+        String[] split = path.split(this.nestedSeparator);
+        Map<Object, Object> current = (Map<Object, Object>) document;
+        for (int i = 0; i < split.length; i++) {
+            String part = split[i];
+            if (i == (split.length - 1)) {
+                return current.remove(part);
+            }
+            Object element = current.get(part);
+            if (element instanceof Map) {
+                current = (Map<Object, Object>) element;
+                continue;
+            }
+            return null;
+        }
+        return null;
+    }
+}

--- a/core/src/main/java/eu/okaeri/configs/migrate/view/ConfigView.java
+++ b/core/src/main/java/eu/okaeri/configs/migrate/view/ConfigView.java
@@ -59,6 +59,15 @@ public abstract class ConfigView implements TypedKeyReader, TypedKeyWriter {
     // ==================== MIGRATION CONVENIENCE METHODS ====================
 
     /**
+     * Returns the internal state map from the associated {@link OkaeriConfig}.
+     *
+     * @return the internal state map
+     */
+    public Map<String, Object> getInternalState() {
+        return this.config.getInternalState();
+    }
+
+    /**
      * Gets the raw value at the specified key path (alias for {@link #getRaw}).
      *
      * @param key the dot-separated key path

--- a/core/src/main/java/eu/okaeri/configs/migrate/view/InternalStateView.java
+++ b/core/src/main/java/eu/okaeri/configs/migrate/view/InternalStateView.java
@@ -8,7 +8,7 @@ import java.util.Collection;
 import java.util.Map;
 
 /**
- * Provides raw key-value access to internalState config data for migrations.
+ * Provides TRUE raw key-value access to internalState config data for migrations.
  * <p>
  * Supports dot-separated nested key paths (e.g., "section.subsection.key").
  * <p>
@@ -55,6 +55,11 @@ public class InternalStateView extends ConfigView {
 
     // ==================== MIGRATION CONVENIENCE METHODS ====================
 
+    /**
+     * Returns the internal state map from the associated {@link OkaeriConfig}.
+     *
+     * @return the internal state map
+     */
     public Map<String, Object> getInternalState() {
         return this.config.getInternalState();
     }

--- a/core/src/main/java/eu/okaeri/configs/migrate/view/InternalStateView.java
+++ b/core/src/main/java/eu/okaeri/configs/migrate/view/InternalStateView.java
@@ -56,15 +56,6 @@ public class InternalStateView extends ConfigView {
     // ==================== MIGRATION CONVENIENCE METHODS ====================
 
     /**
-     * Returns the internal state map from the associated {@link OkaeriConfig}.
-     *
-     * @return the internal state map
-     */
-    public Map<String, Object> getInternalState() {
-        return this.config.getInternalState();
-    }
-
-    /**
      * Checks if a key exists at the specified path.
      *
      * @param key the dot-separated key path

--- a/core/src/main/java/eu/okaeri/configs/migrate/view/InternalStateView.java
+++ b/core/src/main/java/eu/okaeri/configs/migrate/view/InternalStateView.java
@@ -1,0 +1,83 @@
+package eu.okaeri.configs.migrate.view;
+
+import eu.okaeri.configs.OkaeriConfig;
+import eu.okaeri.configs.schema.GenericsDeclaration;
+import lombok.NonNull;
+
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * Provides raw key-value access to internalState config data for migrations.
+ * <p>
+ * Supports dot-separated nested key paths (e.g., "section.subsection.key").
+ * <p>
+ * All reads/writes operate directly on {@code config.getInternalState()}
+ * without triggering deserialization. A single {@code config.update()} call
+ * at the end of ALL migrations syncs internalState to Java fields.
+ */
+public class InternalStateView extends ConfigView {
+
+    public InternalStateView(@NonNull OkaeriConfig config, String nestedSeparator) {
+        super(config, nestedSeparator);
+    }
+
+    public InternalStateView(@NonNull OkaeriConfig config) {
+        super(config);
+    }
+
+    // ==================== INTERFACE REQUIREMENTS ====================
+
+    @Override
+    public Object set(@NonNull String key, Object value, GenericsDeclaration genericType) {
+        return this.setRaw(key, value);
+    }
+
+    @Override
+    public Object getRaw(@NonNull String key) {
+        return this.valueExtract(this.getInternalState(), key);
+    }
+
+    @Override
+    public Object setRaw(@NonNull String key, Object value) {
+        return this.valuePut(this.getInternalState(), key, value);
+    }
+
+    @Override
+    public void setCollection(@NonNull String key, Collection<?> collection, @NonNull GenericsDeclaration genericType) {
+        this.setRaw(key, collection);
+    }
+
+    @Override
+    public void setMap(@NonNull String key, Map<?, ?> map, @NonNull GenericsDeclaration genericType) {
+        this.setRaw(key, map);
+    }
+
+    // ==================== MIGRATION CONVENIENCE METHODS ====================
+
+    public Map<String, Object> getInternalState() {
+        return this.config.getInternalState();
+    }
+
+    /**
+     * Checks if a key exists at the specified path.
+     *
+     * @param key the dot-separated key path
+     * @return true if the key exists
+     */
+    @Override
+    public boolean exists(@NonNull String key) {
+        return this.valueExists(this.getInternalState(), key);
+    }
+
+    /**
+     * Removes the value at the specified key path.
+     *
+     * @param key the dot-separated key path
+     * @return the previous value, or null
+     */
+    @Override
+    public Object remove(@NonNull String key) {
+        return this.valueRemove(this.getInternalState(), key);
+    }
+}

--- a/core/src/main/java/eu/okaeri/configs/migrate/view/RawConfigView.java
+++ b/core/src/main/java/eu/okaeri/configs/migrate/view/RawConfigView.java
@@ -1,15 +1,10 @@
 package eu.okaeri.configs.migrate.view;
 
 import eu.okaeri.configs.OkaeriConfig;
-import eu.okaeri.configs.configurer.Configurer;
-import eu.okaeri.configs.serdes.SerdesContext;
 import eu.okaeri.configs.serdes.TypedKeyReader;
 import eu.okaeri.configs.serdes.TypedKeyWriter;
-import lombok.AllArgsConstructor;
 import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -19,29 +14,17 @@ import java.util.Map;
  * Implements both {@link TypedKeyReader} and {@link TypedKeyWriter} for
  * automatic type resolution and simplification.
  */
-@AllArgsConstructor
-@RequiredArgsConstructor
-public class RawConfigView implements TypedKeyReader, TypedKeyWriter {
+public class RawConfigView extends ConfigView {
 
-    private final OkaeriConfig config;
-    private String nestedSeparator = "\\.";
+    public RawConfigView(@NonNull OkaeriConfig config, String nestedSeparator) {
+        super(config, nestedSeparator);
+    }
+
+    public RawConfigView(@NonNull OkaeriConfig config) {
+        super(config);
+    }
 
     // ==================== INTERFACE REQUIREMENTS ====================
-
-    @Override
-    public Configurer getConfigurer() {
-        return this.config.getConfigurer();
-    }
-
-    @Override
-    public SerdesContext getReaderContext(@NonNull String key) {
-        return SerdesContext.of(this.getConfigurer(), this.config.getContext(), null);
-    }
-
-    @Override
-    public SerdesContext getWriterContext(@NonNull String key) {
-        return SerdesContext.of(this.getConfigurer(), this.config.getContext(), null);
-    }
 
     @Override
     public Object getRaw(@NonNull String key) {
@@ -50,28 +33,14 @@ public class RawConfigView implements TypedKeyReader, TypedKeyWriter {
     }
 
     @Override
-    public void setRaw(@NonNull String key, Object value) {
+    public Object setRaw(@NonNull String key, Object value) {
         Map<String, Object> document = this.config.asMap();
-        this.valuePut(document, key, value);
+        Object old = this.valuePut(document, key, value);
         this.config.load(document);
-    }
-
-    @Override
-    public Object getRawOrNull(@NonNull String key) {
-        return this.getRaw(key);
+        return old;
     }
 
     // ==================== MIGRATION CONVENIENCE METHODS ====================
-
-    /**
-     * Gets the raw value at the specified key path (alias for {@link #getRaw}).
-     *
-     * @param key the dot-separated key path
-     * @return the raw value, or null if not found
-     */
-    public Object get(@NonNull String key) {
-        return this.getRaw(key);
-    }
 
     /**
      * Checks if a key exists at the specified path.
@@ -79,6 +48,7 @@ public class RawConfigView implements TypedKeyReader, TypedKeyWriter {
      * @param key the dot-separated key path
      * @return true if the key exists
      */
+    @Override
     public boolean exists(@NonNull String key) {
         Map<String, Object> document = this.config.asMap();
         return this.valueExists(document, key);
@@ -90,6 +60,7 @@ public class RawConfigView implements TypedKeyReader, TypedKeyWriter {
      * @param key the dot-separated key path
      * @return the previous value, or null
      */
+    @Override
     public Object remove(@NonNull String key) {
         Map<String, Object> document = this.config.asMap();
         Object old = this.valueRemove(document, key);
@@ -104,87 +75,5 @@ public class RawConfigView implements TypedKeyReader, TypedKeyWriter {
 
         this.config.load(document);
         return old;
-    }
-
-    // ==================== NESTED PATH HELPERS ====================
-
-    protected boolean valueExists(Map<?, ?> document, String path) {
-        String[] split = path.split(this.nestedSeparator);
-        for (int i = 0; i < split.length; i++) {
-            String part = split[i];
-            if (i == (split.length - 1)) {
-                return document.containsKey(part);
-            }
-            Object element = document.get(part);
-            if (element instanceof Map) {
-                document = (Map<?, ?>) element;
-                continue;
-            }
-            return false;
-        }
-        return false;
-    }
-
-    protected Object valueExtract(Map<?, ?> document, String path) {
-        String[] split = path.split(this.nestedSeparator);
-        for (int i = 0; i < split.length; i++) {
-            String part = split[i];
-            Object element = document.get(part);
-            if (i == (split.length - 1)) {
-                return element;
-            }
-            if (element instanceof Map) {
-                document = (Map<?, ?>) element;
-                continue;
-            }
-            // can't traverse deeper - return null
-            return null;
-        }
-        return null;
-    }
-
-    @SuppressWarnings("unchecked")
-    protected Object valuePut(Map<?, ?> document, String path, Object value) {
-        String[] split = path.split(this.nestedSeparator);
-        Map<Object, Object> current = (Map<Object, Object>) document;
-        for (int i = 0; i < split.length; i++) {
-            String part = split[i];
-            if (i == (split.length - 1)) {
-                return current.put(part, value);
-            }
-            Object element = current.get(part);
-            if (element instanceof Map) {
-                current = (Map<Object, Object>) element;
-                continue;
-            }
-            if (element != null) {
-                String elementStr = element.getClass().getSimpleName();
-                throw new IllegalArgumentException("Cannot insert '" + path + "': " +
-                    "type conflict (ended at index " + i + " [" + part + ":" + elementStr + "])");
-            }
-            Map<Object, Object> map = new LinkedHashMap<>();
-            current.put(part, map);
-            current = map;
-        }
-        throw new IllegalArgumentException("Cannot put '" + path + "'");
-    }
-
-    @SuppressWarnings("unchecked")
-    protected Object valueRemove(Map<?, ?> document, String path) {
-        String[] split = path.split(this.nestedSeparator);
-        Map<Object, Object> current = (Map<Object, Object>) document;
-        for (int i = 0; i < split.length; i++) {
-            String part = split[i];
-            if (i == (split.length - 1)) {
-                return current.remove(part);
-            }
-            Object element = current.get(part);
-            if (element instanceof Map) {
-                current = (Map<Object, Object>) element;
-                continue;
-            }
-            return null;
-        }
-        return null;
     }
 }

--- a/core/src/main/java/eu/okaeri/configs/migrate/view/RawConfigView.java
+++ b/core/src/main/java/eu/okaeri/configs/migrate/view/RawConfigView.java
@@ -67,7 +67,7 @@ public class RawConfigView extends ConfigView {
 
         // top-level keys need to be removed from internalState as well
         if (key.split(this.nestedSeparator).length == 1) {
-            Map<String, Object> internalState = this.config.getInternalState();
+            Map<String, Object> internalState = this.getInternalState();
             if (internalState != null) {
                 internalState.remove(key);
             }

--- a/core/src/main/java/eu/okaeri/configs/serdes/SerializationData.java
+++ b/core/src/main/java/eu/okaeri/configs/serdes/SerializationData.java
@@ -69,8 +69,8 @@ public class SerializationData implements TypedKeyWriter {
     // ==================== CORE WRITE METHOD ====================
 
     @Override
-    public void setRaw(@NonNull String key, Object value) {
-        this.data.put(key, value);
+    public Object setRaw(@NonNull String key, Object value) {
+        return this.data.put(key, value);
     }
 
     // ==================== VALUE METHODS ====================

--- a/core/src/main/java/eu/okaeri/configs/serdes/TypedKeyReader.java
+++ b/core/src/main/java/eu/okaeri/configs/serdes/TypedKeyReader.java
@@ -14,6 +14,7 @@ import java.util.*;
  *
  * @see DeserializationData
  * @see eu.okaeri.configs.migrate.view.RawConfigView
+ * @see eu.okaeri.configs.migrate.view.InternalStateView
  */
 public interface TypedKeyReader {
 

--- a/core/src/main/java/eu/okaeri/configs/serdes/TypedKeyWriter.java
+++ b/core/src/main/java/eu/okaeri/configs/serdes/TypedKeyWriter.java
@@ -17,6 +17,7 @@ import java.util.Map;
  *
  * @see SerializationData
  * @see eu.okaeri.configs.migrate.view.RawConfigView
+ * @see eu.okaeri.configs.migrate.view.InternalStateView
  */
 public interface TypedKeyWriter {
 
@@ -38,8 +39,9 @@ public interface TypedKeyWriter {
      *
      * @param key the key
      * @param value the raw value
+     * @return the previous raw value, or null
      */
-    void setRaw(@NonNull String key, Object value);
+    Object setRaw(@NonNull String key, Object value);
 
     /**
      * Gets the raw value at the specified key (for returning old value on set).
@@ -61,10 +63,7 @@ public interface TypedKeyWriter {
      * @return the previous raw value, or null
      */
     default Object set(@NonNull String key, Object value) {
-        Object old = this.getRawOrNull(key);
-        value = this.getConfigurer().simplify(value, null, this.getWriterContext(key), true);
-        this.setRaw(key, value);
-        return old;
+        return this.set(key, value, (GenericsDeclaration) null);
     }
 
     /**
@@ -75,7 +74,7 @@ public interface TypedKeyWriter {
      * @param genericType the type declaration for simplification
      * @return the previous raw value, or null
      */
-    default Object set(@NonNull String key, Object value, @NonNull GenericsDeclaration genericType) {
+    default Object set(@NonNull String key, Object value, GenericsDeclaration genericType) {
         Object old = this.getRawOrNull(key);
         value = this.getConfigurer().simplify(value, genericType, this.getWriterContext(key), true);
         this.setRaw(key, value);

--- a/hjson/src/main/java/eu/okaeri/configs/hjson/HjsonConfigurer.java
+++ b/hjson/src/main/java/eu/okaeri/configs/hjson/HjsonConfigurer.java
@@ -93,7 +93,8 @@ public class HjsonConfigurer extends Configurer {
         json.setFullComment(CommentType.BOL, header);
 
         // save
-        ConfigPostprocessor.of(json.toString(Stringify.HJSON_COMMENTS)).write(outputStream);
+        String hjson = json.toString(Stringify.HJSON_COMMENTS).replace("\r\n", "\n");
+        ConfigPostprocessor.of(hjson).write(outputStream);
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
Adds an additional migration system for "true" raw internalState migrating without ANY (de)serialization for individual migrations.

Instead, (de)serialization is done after ALL migrations are complete, allowing an older migration to succeed while modifying a key/value that has a broken structure for (a) serializer(s) that *may* later be fixed by a future migration down the pipeline (if the structure still isn't fixed/resolved by the end of the internal state migration pipline, loading will fail [obviously]).

Existing migration behavior *should* still work, I barely changed anything with that flow (no changes needed from users).

`ConfigView` was made from `RawConfigView`, and is also the super-class of `InternalStateView`. This offers common code for both views while avoiding changing code/behavior for the existing migration system.

To use the new system, users simply have to switch `migrate` -> `migrateInternalState`. All methods from the old `RawConfigView` also existin `InternalStateView`, so they shouldn't need really change anything (unless they rely on serialization). ~~Since the new view is an `InternalStateView`, they can cast the passed `ConfigView` to access `InternalStateView#getInternalState()`.~~ *(see https://github.com/OkaeriPoland/okaeri-configs/pull/55#issuecomment-4753833506)*

`migrateInternalState(...)` should be called before any `migrate(...)` calls, as the internal state migrations may fix serializer structures before `migrate(...)` requires them to be valid.

All existing Okaeri Configs test pass and all personal testing passed with my plugins.

### Miscellenous changes

- [Fix tests on Windows](https://github.com/OkaeriPoland/okaeri-configs/commit/bf14a676f462edc3ca2acf26d68dc4ab5524f0db)
  - Line endings broke a few tests for me for some reason, so I just replaced `\r\n` with `\n` in the HJSON configurer and golden file test. This doesn't really seem like the best/cleanest solution, but I just wanted tests to work 🙃
- [Use try-with-resources for `OkaeriConfig#load(File)`](https://github.com/OkaeriPoland/okaeri-configs/commit/d38fd101658a77064ed87f98d2773d4e6e388c1f)
  - More tests were failing because this `FileInputStream` wasn't being closed after being used, not sure why it wasn't a try-with-resources before (everything else is)Copy of srnyx@39577bc