### PR TITLE
Add IncludePosition for `@Include`

### DIFF
--- a/core-test/src/test/java/eu/okaeri/configs/annotations/IncludeAnnotationTest.java
+++ b/core-test/src/test/java/eu/okaeri/configs/annotations/IncludeAnnotationTest.java
@@ -3,6 +3,7 @@ package eu.okaeri.configs.annotations;
 import eu.okaeri.configs.ConfigManager;
 import eu.okaeri.configs.OkaeriConfig;
 import eu.okaeri.configs.annotation.Include;
+import eu.okaeri.configs.annotation.IncludePosition;
 import eu.okaeri.configs.annotation.Includes;
 import eu.okaeri.configs.schema.ConfigDeclaration;
 import eu.okaeri.configs.schema.FieldDeclaration;
@@ -10,6 +11,8 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -78,6 +81,40 @@ class IncludeAnnotationTest {
     @EqualsAndHashCode(callSuper = false)
     @Include(ConflictingBase.class)
     public static class ConflictingIncludeConfig extends ConflictingBase {
+        private String conflictField = "from child";
+        private String childField = "child";
+    }
+
+    // ===== Test Configs - Position (BEFORE) =====
+
+    @Data
+    @EqualsAndHashCode(callSuper = false)
+    @Include(value = BaseConfig.class, position = IncludePosition.BEFORE)
+    public static class BeforeIncludeConfig extends BaseConfig {
+        private String ownField = "own";
+    }
+
+    @Data
+    @EqualsAndHashCode(callSuper = false)
+    @Include(value = ConflictingBase.class, position = IncludePosition.BEFORE)
+    public static class BeforeConflictingConfig extends ConflictingBase {
+        private String conflictField = "from child";
+        private String childField = "child";
+    }
+
+    // ===== Test Configs - Position (AFTER explicit) =====
+
+    @Data
+    @EqualsAndHashCode(callSuper = false)
+    @Include(value = BaseConfig.class, position = IncludePosition.AFTER)
+    public static class AfterIncludeConfig extends BaseConfig {
+        private String ownField = "own";
+    }
+
+    @Data
+    @EqualsAndHashCode(callSuper = false)
+    @Include(value = ConflictingBase.class, position = IncludePosition.AFTER)
+    public static class AfterConflictingConfig extends ConflictingBase {
         private String conflictField = "from child";
         private String childField = "child";
     }
@@ -185,5 +222,95 @@ class IncludeAnnotationTest {
         assertThat(field1.getStartingValue()).isEqualTo("base1");
         assertThat(field2).isNotNull();
         assertThat(field2.getStartingValue()).isEqualTo("base2");
+    }
+
+    // ===== Position Tests =====
+
+    @Test
+    void testInclude_DefaultPosition_IsAfter() {
+        // Given
+        ConfigDeclaration declaration = ConfigDeclaration.of(SingleIncludeConfig.class);
+
+        // When
+        Set<String> fieldNames = declaration.getFieldNames();
+
+        // Then - @Include without explicit position should behave as AFTER
+        assertThat(fieldNames).containsExactly("ownField", "baseField1", "baseField2");
+    }
+
+    @Test
+    void testInclude_PositionBefore_IncludedFieldsAppearFirst() {
+        // Given
+        ConfigDeclaration declaration = ConfigDeclaration.of(BeforeIncludeConfig.class);
+
+        // When
+        Set<String> fieldNames = declaration.getFieldNames();
+
+        // Then
+        assertThat(fieldNames).containsExactly("baseField1", "baseField2", "ownField");
+    }
+
+    @Test
+    void testInclude_PositionAfter_IncludedFieldsAppearLast() {
+        // Given
+        ConfigDeclaration declaration = ConfigDeclaration.of(AfterIncludeConfig.class);
+
+        // When
+        Set<String> fieldNames = declaration.getFieldNames();
+
+        // Then
+        assertThat(fieldNames).containsExactly("ownField", "baseField1", "baseField2");
+    }
+
+    @Test
+    void testInclude_PositionBefore_ConflictingField_ChildWins() {
+        // Given
+        BeforeConflictingConfig config = ConfigManager.create(BeforeConflictingConfig.class);
+
+        // When
+        ConfigDeclaration declaration = config.getDeclaration();
+        FieldDeclaration conflictField = declaration.getField("conflictField").orElse(null);
+
+        // Then
+        assertThat(conflictField).isNotNull();
+        assertThat(conflictField.getStartingValue()).isEqualTo("from child");
+    }
+
+    @Test
+    void testInclude_PositionBefore_ConflictingField_OrderedAtClassPosition() {
+        // Given
+        ConfigDeclaration declaration = ConfigDeclaration.of(BeforeConflictingConfig.class);
+
+        // When
+        Set<String> fieldNames = declaration.getFieldNames();
+
+        // Then - Non-conflicting BEFORE fields come first; conflicting field appears at its class-declared position
+        assertThat(fieldNames).containsExactly("uniqueField", "conflictField", "childField");
+    }
+
+    @Test
+    void testInclude_PositionAfter_ConflictingField_ChildWins() {
+        // Given
+        AfterConflictingConfig config = ConfigManager.create(AfterConflictingConfig.class);
+
+        // When
+        ConfigDeclaration declaration = config.getDeclaration();
+        FieldDeclaration conflictField = declaration.getField("conflictField").orElse(null);
+
+        // Then
+        assertThat(conflictField).isNotNull();
+        assertThat(conflictField.getStartingValue()).isEqualTo("from child");
+    }
+
+    @Test
+    void testInclude_PositionAfter_ConflictingField_ClassFieldsOrderedFirst() {
+        // Given
+        ConfigDeclaration declaration = ConfigDeclaration.of(AfterConflictingConfig.class);
+
+        // When
+        Set<String> fieldNames = declaration.getFieldNames();
+
+        // Then - Class fields come first; non-conflicting AFTER fields are appended
+        assertThat(fieldNames).containsExactly("conflictField", "childField", "uniqueField");
     }
 }

--- a/core/src/main/java/eu/okaeri/configs/annotation/Include.java
+++ b/core/src/main/java/eu/okaeri/configs/annotation/Include.java
@@ -9,4 +9,6 @@ import java.lang.annotation.*;
 @Repeatable(Includes.class)
 public @interface Include {
     Class<? extends OkaeriConfig> value();
+
+    IncludePosition position() default IncludePosition.AFTER;
 }

--- a/core/src/main/java/eu/okaeri/configs/annotation/IncludePosition.java
+++ b/core/src/main/java/eu/okaeri/configs/annotation/IncludePosition.java
@@ -1,0 +1,6 @@
+package eu.okaeri.configs.annotation;
+
+public enum IncludePosition {
+    BEFORE,
+    AFTER
+}

--- a/core/src/main/java/eu/okaeri/configs/schema/ConfigDeclaration.java
+++ b/core/src/main/java/eu/okaeri/configs/schema/ConfigDeclaration.java
@@ -43,8 +43,13 @@ public class ConfigDeclaration {
         declaration.setHeader(template.getHeader());
         declaration.setReal(template.isReal());
         declaration.setType(template.getType());
-        declaration.setFieldMap(readFields(clazz, declaration, object));
 
+        // Get fields from this class (call before @Include readFields for correct cache)
+        Map<String, FieldDeclaration> thisFields = readFields(clazz, declaration, object);
+
+        // Get @Include fields
+        Map<String, FieldDeclaration> includeFieldsBefore = new LinkedHashMap<>();
+        Map<String, FieldDeclaration> includeFieldsAfter = new LinkedHashMap<>();
         Include[] subs = clazz.getDeclaredAnnotationsByType(Include.class);
         for (Include sub : subs) {
             if (!sub.value().isAssignableFrom(clazz)) {
@@ -53,14 +58,39 @@ public class ConfigDeclaration {
                     "Cannot include fields from " + sub.value().getName() + " because it is not a superclass of " + clazz.getName()
                 );
             }
+
+            // Get target map
+            Map<String, FieldDeclaration> target;
+            switch (sub.position()) {
+                case BEFORE:
+                    target = includeFieldsBefore;
+                    break;
+                case AFTER:
+                    target = includeFieldsAfter;
+                    break;
+                default:
+                    throw new IllegalArgumentException(
+                        "Unknown @Include position: " + sub.position() + ". " +
+                        "Cannot include fields from " + sub.value().getName() + " because it has an unknown position"
+                    );
+            }
+
+            // Add fields to target
             Map<String, FieldDeclaration> subFields = readFields(sub.value(), declaration, object);
-            subFields.forEach((key, value) -> {
-                if (declaration.getFieldMap().containsKey(key)) {
-                    return;
-                }
-                declaration.getFieldMap().put(key, value);
-            });
+            subFields.forEach(target::putIfAbsent);
         }
+
+        // @Include position = before (overwriting is not a concern)
+        Map<String, FieldDeclaration> allFields = new LinkedHashMap<>(includeFieldsBefore);
+        // Fields from this class (move conflicts down)
+        thisFields.forEach((string, field) -> {
+            allFields.remove(string);
+            allFields.put(string, field);
+        });
+        // @Include position = after (overwriting is NOT okay)
+        includeFieldsAfter.forEach(allFields::putIfAbsent);
+
+        declaration.setFieldMap(allFields);
 
         return declaration;
     }


### PR DESCRIPTION
This allows `@Include` configs to appear **before** the annotated class' fields in the config file, which is useful if you want to "expand upon" an existing config class, rather than *just* include the existing class' fields.

Default behavior is the same as before: `IncludeLocation.AFTER`

Tests were added for it and they all passed. Local testing was also done with my own plugin and it works.