### PR TITLE
Add configurable line width for YAML configurers

### DIFF
--- a/yaml-bukkit/pom.xml
+++ b/yaml-bukkit/pom.xml
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.12.2-R0.1-SNAPSHOT</version>
+            <version>1.18.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
 

--- a/yaml-bukkit/src/main/java/eu/okaeri/configs/yaml/bukkit/YamlBukkitConfigurer.java
+++ b/yaml-bukkit/src/main/java/eu/okaeri/configs/yaml/bukkit/YamlBukkitConfigurer.java
@@ -21,6 +21,7 @@ import java.util.Map;
 public class YamlBukkitConfigurer extends Configurer {
 
     @Setter private String commentPrefix = "# ";
+    @Setter private int lineWidth = 80;
 
     @Override
     public List<String> getExtensions() {
@@ -47,6 +48,11 @@ public class YamlBukkitConfigurer extends Configurer {
 
         YamlConfiguration config = new YamlConfiguration();
         config.options().pathSeparator((char) 29); // 'group separator': disables dot parsing in set/get
+        try {
+            config.options().width(this.lineWidth);
+        } catch (NoSuchMethodError e) {
+            // width option not supported in older versions, ignore
+        }
 
         for (Map.Entry<String, Object> entry : data.entrySet()) {
             config.set(entry.getKey(), entry.getValue());

--- a/yaml-jackson/src/main/java/eu/okaeri/configs/yaml/jackson/YamlJacksonConfigurer.java
+++ b/yaml-jackson/src/main/java/eu/okaeri/configs/yaml/jackson/YamlJacksonConfigurer.java
@@ -10,18 +10,17 @@ import eu.okaeri.configs.configurer.Configurer;
 import eu.okaeri.configs.format.yaml.YamlSourceWalker;
 import eu.okaeri.configs.postprocessor.ConfigPostprocessor;
 import eu.okaeri.configs.schema.ConfigDeclaration;
-import eu.okaeri.configs.schema.FieldDeclaration;
-import eu.okaeri.configs.schema.GenericsDeclaration;
-import eu.okaeri.configs.serdes.SerdesContext;
 import lombok.NonNull;
 import lombok.Setter;
 import lombok.experimental.Accessors;
+import org.yaml.snakeyaml.DumperOptions;
 
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
+import java.util.function.Supplier;
 
 /**
  * YAML configurer using Jackson's YAML dataformat for parsing and serialization.
@@ -40,23 +39,48 @@ public class YamlJacksonConfigurer extends Configurer {
     private static final TypeReference<LinkedHashMap<String, Object>> MAP_TYPE = new TypeReference<LinkedHashMap<String, Object>>() {
     };
 
-    private @Setter ObjectMapper mapper;
+    // Need to cache for things like lineWidth to work with default mapper.
+    // Else, createDefaultMapper would be called, creating a new mapper, every read/write (not needed as ObjectMapper is thread-safe).
+    private ObjectMapper cachedMapper;
+    private Supplier<ObjectMapper> mapper;
     private @Setter String commentPrefix = "# ";
+    private int lineWidth = 80;
 
     public YamlJacksonConfigurer() {
-        this.mapper = createDefaultMapper();
+        this.mapper = this::createDefaultMapper;
     }
 
     public YamlJacksonConfigurer(@NonNull ObjectMapper mapper) {
-        this.mapper = mapper;
+        this.mapper = () -> mapper;
     }
 
-    private static ObjectMapper createDefaultMapper() {
+    public YamlJacksonConfigurer setMapper(@NonNull ObjectMapper mapper) {
+        this.mapper = () -> mapper;
+
+        // Reset cached mapper
+        this.cachedMapper = null;
+        return this;
+    }
+
+    public YamlJacksonConfigurer setLineWidth(int lineWidth) {
+        this.lineWidth = lineWidth;
+
+        // Reset cached mapper
+        this.cachedMapper = null;
+        return this;
+    }
+
+    private ObjectMapper createDefaultMapper() {
+        DumperOptions dumperOptions = new DumperOptions();
+        dumperOptions.setWidth(this.lineWidth);
+
         YAMLFactory factory = YAMLFactory.builder()
+            .dumperOptions(dumperOptions)
             .disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER)
             .enable(YAMLGenerator.Feature.MINIMIZE_QUOTES)
             .enable(YAMLGenerator.Feature.ALWAYS_QUOTE_NUMBERS_AS_STRINGS)
             .build();
+
         YAMLMapper mapper = new YAMLMapper(factory);
         mapper.disable(JsonGenerator.Feature.AUTO_CLOSE_TARGET);
         return mapper;
@@ -69,14 +93,21 @@ public class YamlJacksonConfigurer extends Configurer {
 
     @Override
     public Map<String, Object> load(@NonNull InputStream inputStream, @NonNull ConfigDeclaration declaration) throws Exception {
-        return this.mapper.readValue(inputStream, MAP_TYPE);
+        if (this.cachedMapper == null) {
+            this.cachedMapper = this.mapper.get();
+        }
+
+        return this.cachedMapper.readValue(inputStream, MAP_TYPE);
     }
 
     @Override
     public void write(@NonNull OutputStream outputStream, @NonNull Map<String, Object> data, @NonNull ConfigDeclaration declaration) throws Exception {
+        if (this.cachedMapper == null) {
+            this.cachedMapper = this.mapper.get();
+        }
 
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        this.mapper.writeValue(baos, data);
+        this.cachedMapper.writeValue(baos, data);
 
         ConfigPostprocessor.of(baos.toString(StandardCharsets.UTF_8.name()))
             .removeLines(line -> line.startsWith(this.commentPrefix.trim()))

--- a/yaml-snakeyaml/src/main/java/eu/okaeri/configs/yaml/snakeyaml/YamlSnakeYamlConfigurer.java
+++ b/yaml-snakeyaml/src/main/java/eu/okaeri/configs/yaml/snakeyaml/YamlSnakeYamlConfigurer.java
@@ -26,7 +26,7 @@ public class YamlSnakeYamlConfigurer extends Configurer {
 
     private final Supplier<Yaml> yaml;
     private @Setter String commentPrefix = "# ";
-    private @Setter int lineWidth = Integer.MAX_VALUE;
+    private @Setter int lineWidth = 80;
 
     public YamlSnakeYamlConfigurer() {
         this.yaml = this::createYaml;

--- a/yaml-snakeyaml/src/main/java/eu/okaeri/configs/yaml/snakeyaml/YamlSnakeYamlConfigurer.java
+++ b/yaml-snakeyaml/src/main/java/eu/okaeri/configs/yaml/snakeyaml/YamlSnakeYamlConfigurer.java
@@ -26,21 +26,23 @@ public class YamlSnakeYamlConfigurer extends Configurer {
 
     private final Supplier<Yaml> yaml;
     private @Setter String commentPrefix = "# ";
+    private @Setter int lineWidth = Integer.MAX_VALUE;
 
     public YamlSnakeYamlConfigurer() {
-        this(YamlSnakeYamlConfigurer::createYaml);
+        this.yaml = this::createYaml;
     }
 
     public YamlSnakeYamlConfigurer(@NonNull Supplier<Yaml> yaml) {
         this.yaml = yaml;
     }
 
-    private static Yaml createYaml() {
+    private Yaml createYaml() {
 
         LoaderOptions loaderOptions = new LoaderOptions();
         Constructor constructor = new Constructor(loaderOptions);
 
         DumperOptions dumperOptions = new DumperOptions();
+        dumperOptions.setWidth(this.lineWidth);
         dumperOptions.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
 
         Representer representer = new Representer(dumperOptions);


### PR DESCRIPTION
- `YamlBukkitConfigurer`
  - Required updating Spigot runtime from 1.12.2 -> 1.18.1, but NoSuchMethodError is caught when setting line width, so should be okay!
- `YamlSnakeYamlConfigurer`
- `YamlJacksonConfigurer`
  - We need to cache the ObjectMapper here as it's thread-safe and doesn't need to be re-created every read/write like with YamlSnakeYamlConfigurer.
  - This also means that any changes to options must reset the cached wrapper to actually apply those new options.

The default value before for all three was 80, which is still the case with these changes.

Tested locally with my own plugin.